### PR TITLE
Add GitHubServerConfig and Environment class

### DIFF
--- a/app/src/main/java/com/example/getaaccontributors/api/config/Environment.kt
+++ b/app/src/main/java/com/example/getaaccontributors/api/config/Environment.kt
@@ -1,0 +1,8 @@
+package com.example.getaaccontributors.api.config
+
+class Environment(var serverConfig: ServerConfig) {
+
+    fun getBaseUrl(): String {
+        return serverConfig.apiBaseUrl()
+    }
+}

--- a/app/src/main/java/com/example/getaaccontributors/api/config/ServerConfig.kt
+++ b/app/src/main/java/com/example/getaaccontributors/api/config/ServerConfig.kt
@@ -1,0 +1,15 @@
+package com.example.getaaccontributors.api.config
+
+abstract class ServerConfig {
+    protected abstract fun domain(): String
+    protected abstract fun scheme(): String
+    protected abstract fun apiHost(): String
+
+    fun apiDomain(): String {
+        return apiHost() + "." + domain()
+    }
+
+    fun apiBaseUrl(): String {
+        return scheme() + "://" + apiDomain()
+    }
+}

--- a/app/src/main/java/com/example/getaaccontributors/api/github/GitHubServerConfig.kt
+++ b/app/src/main/java/com/example/getaaccontributors/api/github/GitHubServerConfig.kt
@@ -1,0 +1,24 @@
+package com.example.getaaccontributors.api.github
+
+import com.example.getaaccontributors.api.config.ServerConfig
+
+class GitHubServerConfig : ServerConfig() {
+
+    override fun domain(): String {
+        return DOMAIN
+    }
+
+    override fun scheme(): String {
+        return API_SCHEME
+    }
+
+    override fun apiHost(): String {
+        return API_HOST
+    }
+
+    private companion object {
+        private const val API_HOST = "api"
+        private const val DOMAIN = "github.com"
+        private const val API_SCHEME = "https"
+    }
+}


### PR DESCRIPTION
# Summary
- Create a GitHubServerConfig class to represent the following
  - API_HOST
  - DOMAIN
  - API_SCHEME
- Environment class will help to switch ServerConfig in the future