### PR TITLE
Add GithubService retrofit interface

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,4 +45,8 @@ dependencies {
 
     // gson
     implementation "com.google.code.gson:gson:$gson_version"
+
+    // Retrofit
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
 }

--- a/app/src/main/java/com/example/getaaccontributors/api/github/GitHubService.kt
+++ b/app/src/main/java/com/example/getaaccontributors/api/github/GitHubService.kt
@@ -1,0 +1,16 @@
+package com.example.getaaccontributors.api.github
+
+import com.example.getaaccontributors.model.UserList
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface GitHubService {
+
+    @GET("repositories/{repo_id}/contributors")
+    suspend fun getContributors(
+        @Path("repo_id") repoId: String,
+        @Query("page") page: Int
+    ): Response<UserList>
+}

--- a/build.gradle
+++ b/build.gradle
@@ -27,4 +27,5 @@ task clean(type: Delete) {
 
 ext {
     gson_version = "2.8.6"
+    retrofit_version = "2.9.0"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun May 30 15:19:43 JST 2021
+#Sun May 30 16:58:57 JST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
# Summary
- Add GitHubService interface to call the request like as `https://api.github.com/repositories/90792131/contributors`
- `page` query parameter is added to correspond to pagination
  - ref: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#pagination