### PR TITLE
Add HomeAdapter without the unit test

### DIFF
--- a/app/src/main/java/com/example/getaaccontributors/feature/home/view/HomeAdapter.kt
+++ b/app/src/main/java/com/example/getaaccontributors/feature/home/view/HomeAdapter.kt
@@ -1,0 +1,53 @@
+package com.example.getaaccontributors.feature.home.view
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
+import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.DiffUtil
+import com.example.getaaccontributors.R
+import com.example.getaaccontributors.feature.home.contract.HomeContract
+import com.example.getaaccontributors.model.UserList
+
+class HomeAdapter : PagingDataAdapter<UserList.User, HomeViewHolder>(DIFF_CALLBACK) {
+
+    var listener: HomeContract.UserClickListener? = null
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HomeViewHolder {
+        return createHomeViewHolder(parent)
+    }
+
+    override fun onBindViewHolder(holder: HomeViewHolder, position: Int) {
+        getUser(position)?.run { holder.bind(this, listener) }
+    }
+
+    @VisibleForTesting
+    internal fun createHomeViewHolder(parent: ViewGroup): HomeViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.view_home_user, parent, false)
+        return HomeViewHolder(view)
+    }
+
+    @VisibleForTesting
+    internal fun getUser(position: Int) = getItem(position)
+
+    companion object {
+        @VisibleForTesting
+        internal val DIFF_CALLBACK = object : DiffUtil.ItemCallback<UserList.User>() {
+
+            override fun areItemsTheSame(
+                oldItem: UserList.User,
+                newItem: UserList.User
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: UserList.User,
+                newItem: UserList.User
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary
- Implement PagingDataAdapter to create ViewHolder and bind data to each views by using it
- I don't implement the unit test yet, because the adapter cannot be initialized for Internally throwing a null pointer exception. I will add the unit test after finding a solution.