### PR TITLE
Add getRepos to GitHubService

### DIFF
--- a/app/src/main/java/com/example/getaaccontributors/api/github/GitHubService.kt
+++ b/app/src/main/java/com/example/getaaccontributors/api/github/GitHubService.kt
@@ -1,5 +1,6 @@
 package com.example.getaaccontributors.api.github
 
+import com.example.getaaccontributors.model.RepoList
 import com.example.getaaccontributors.model.UserList
 import retrofit2.Response
 import retrofit2.http.GET
@@ -13,4 +14,10 @@ interface GitHubService {
         @Path("repo_id") repoId: String,
         @Query("page") page: Int
     ): Response<UserList>
+
+    @GET("users/{user_id}/repos")
+    suspend fun getRepos(
+        @Path("repo_id") repoId: String,
+        @Query("page") page: Int
+    ): Response<RepoList>
 }


### PR DESCRIPTION
## Summary
- Add getRepos function into GitHubService interface to call the request like as `https://api.github.com/users/ianhanniballake/repos`
- `page` query parameter is added to correspond to pagination
  - ref: https://docs.github.com/ja/rest/reference/repos#list-repositories-for-a-user