### PR TITLE
Add getUser to GitHubService

### DIFF
--- a/app/src/main/java/com/example/getaaccontributors/api/github/GitHubService.kt
+++ b/app/src/main/java/com/example/getaaccontributors/api/github/GitHubService.kt
@@ -20,4 +20,9 @@ interface GitHubService {
         @Path("username") userName: String,
         @Query("page") page: Int
     ): Response<RepoList>
+
+    @GET("users/{username}")
+    suspend fun getUser(
+        @Path("username") userName: String
+    ): Response<UserList.User>
 }

--- a/app/src/main/java/com/example/getaaccontributors/model/UserList.kt
+++ b/app/src/main/java/com/example/getaaccontributors/model/UserList.kt
@@ -43,6 +43,34 @@ class UserList : ArrayList<UserList.User>() {
         @SerializedName("site_admin")
         val siteAdmin: Boolean,
         @SerializedName("contributions")
-        val contributions: Int
+        val contributions: Int,
+        @SerializedName("name")
+        val name: String,
+        @SerializedName("company")
+        val company: String,
+        @SerializedName("blog")
+        val blog: String,
+        @SerializedName("location")
+        val location: String,
+        @SerializedName("email")
+        val email: Any?,
+        @SerializedName("hireable")
+        val hireable: Any?,
+        @SerializedName("bio")
+        val bio: Any?,
+        @SerializedName("twitter_username")
+        val twitterUsername: String,
+        @SerializedName("public_repos")
+        val publicRepos: Int,
+        @SerializedName("public_gists")
+        val publicGists: Int,
+        @SerializedName("followers")
+        val followers: Int,
+        @SerializedName("following")
+        val following: Int,
+        @SerializedName("created_at")
+        val createdAt: String,
+        @SerializedName("updated_at")
+        val updatedAt: String
     ) : Serializable
 }


### PR DESCRIPTION
## Summary
- Add getUser function into GitHubService interface to call the request like as `https://api.github.com/users/ianhanniballake`
  - ref: https://docs.github.com/ja/rest/reference/users#get-a-user
- Fix params of User data class to adapt to the new api method