### PR TITLE
Remove unnecessary visibility function & change getRepos to suspend function

### DIFF
--- a/app/src/main/java/com/example/getaaccontributors/feature/detail/repos/contract/DetailReposContract.kt
+++ b/app/src/main/java/com/example/getaaccontributors/feature/detail/repos/contract/DetailReposContract.kt
@@ -25,8 +25,6 @@ interface DetailReposContract {
         fun hideRecyclerView()
         fun showErrorView()
         fun hideErrorView()
-        fun showEmptyView()
-        fun hideEmptyView()
         fun showLoadingView()
         fun hideLoadingView()
         fun setOnRefreshListener(listener: RefreshListener)
@@ -44,6 +42,6 @@ interface DetailReposContract {
     }
 
     interface Presenter {
-        fun getRepos(userName: String)
+        suspend fun getRepos(userName: String)
     }
 }

--- a/app/src/main/java/com/example/getaaccontributors/feature/detail/repos/presenter/DetailReposPresenter.kt
+++ b/app/src/main/java/com/example/getaaccontributors/feature/detail/repos/presenter/DetailReposPresenter.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.OnLifecycleEvent
 import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
 import com.example.getaaccontributors.feature.detail.repos.contract.DetailReposContract
-import com.example.getaaccontributors.model.RepoList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
@@ -43,7 +42,7 @@ class DetailReposPresenter @Inject constructor(
     fun onLifecycleEventOnDestroy() = cancel()
 
 
-    override fun getRepos(userName: String) {
+    override suspend fun getRepos(userName: String) {
         launch {
             repository.getRepos(userName).collect {
                 viewProxy.submitData(it)
@@ -60,7 +59,6 @@ class DetailReposPresenter @Inject constructor(
             is LoadState.NotLoading -> {
                 viewProxy.run {
                     showRecyclerView()
-                    hideEmptyView()
                     hideErrorView()
                     hideLoadingView()
                 }
@@ -69,7 +67,6 @@ class DetailReposPresenter @Inject constructor(
                 viewProxy.run {
                     showLoadingView()
                     hideRecyclerView()
-                    hideEmptyView()
                     hideErrorView()
                 }
             }
@@ -78,7 +75,6 @@ class DetailReposPresenter @Inject constructor(
                     showErrorView()
                     hideLoadingView()
                     hideRecyclerView()
-                    hideEmptyView()
                     showErrorMessage(refresh.error)
                 }
             }

--- a/app/src/main/java/com/example/getaaccontributors/feature/detail/repos/view/DetailFragment.kt
+++ b/app/src/main/java/com/example/getaaccontributors/feature/detail/repos/view/DetailFragment.kt
@@ -29,6 +29,6 @@ class DetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        presenter.getRepos(args.userName)
+//        presenter.getRepos(args.userName)
     }
 }

--- a/app/src/main/java/com/example/getaaccontributors/feature/detail/repos/view/DetailViewReposProxy.kt
+++ b/app/src/main/java/com/example/getaaccontributors/feature/detail/repos/view/DetailViewReposProxy.kt
@@ -73,14 +73,6 @@ class DetailViewReposProxy @Inject constructor(
         errorView?.isVisible = false
     }
 
-    override fun showEmptyView() {
-        emptyView?.isVisible = true
-    }
-
-    override fun hideEmptyView() {
-        emptyView?.isVisible = false
-    }
-
     override fun showLoadingView() {
         progressBar?.isVisible = true
     }

--- a/app/src/main/res/layout/view_detail_repos.xml
+++ b/app/src/main/res/layout/view_detail_repos.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/view_detail_repos"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -14,5 +15,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.core.widget.ContentLoadingProgressBar
+        android:id="@+id/progress_bar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/recycler_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/example/getaaccontributors/feature/detail/repos/presenter/DetailReposPresenterTest.kt
+++ b/app/src/test/java/com/example/getaaccontributors/feature/detail/repos/presenter/DetailReposPresenterTest.kt
@@ -116,7 +116,6 @@ internal class DetailReposPresenterTest {
         presenter.onLoadState(loadState)
 
         verify(viewProxy).showRecyclerView()
-        verify(viewProxy).hideEmptyView()
         verify(viewProxy).hideErrorView()
         verify(viewProxy).hideLoadingView()
     }
@@ -131,7 +130,6 @@ internal class DetailReposPresenterTest {
 
         verify(viewProxy).showLoadingView()
         verify(viewProxy).hideRecyclerView()
-        verify(viewProxy).hideEmptyView()
         verify(viewProxy).hideErrorView()
     }
 
@@ -147,7 +145,6 @@ internal class DetailReposPresenterTest {
         verify(viewProxy).showErrorView()
         verify(viewProxy).hideLoadingView()
         verify(viewProxy).hideRecyclerView()
-        verify(viewProxy).hideEmptyView()
         verify(viewProxy).showErrorMessage(exception)
     }
     // endregion

--- a/app/src/test/java/com/example/getaaccontributors/feature/detail/repos/view/DetailReposViewProxyTest.kt
+++ b/app/src/test/java/com/example/getaaccontributors/feature/detail/repos/view/DetailReposViewProxyTest.kt
@@ -29,14 +29,12 @@ internal class DetailReposViewProxyTest {
     private lateinit var viewProxy: DetailViewReposProxy
     private val recyclerView: RecyclerView = mock()
     private val errorView: View = mock()
-    private val emptyView: View = mock()
     private val progressBar: ContentLoadingProgressBar = mock()
     private val refreshButton: Button = mock()
     private val swipeRefreshLayout: SwipeRefreshLayout = mock()
     private val view: View = mock {
         on { findViewById<RecyclerView>(R.id.recycler_view) } doReturn recyclerView
         on { findViewById<View>(R.id.error_view) } doReturn errorView
-        on { findViewById<View>(R.id.empty_view) } doReturn emptyView
         on { findViewById<ContentLoadingProgressBar>(R.id.progress_bar) } doReturn progressBar
         on { findViewById<Button>(R.id.refresh_button) } doReturn refreshButton
         on { findViewById<SwipeRefreshLayout>(R.id.swipe_refresh_layout) } doReturn swipeRefreshLayout
@@ -109,20 +107,6 @@ internal class DetailReposViewProxyTest {
         viewProxy.hideErrorView()
 
         verify(errorView).isVisible = false
-    }
-
-    @Test
-    fun `showEmptyView should show emptyView`() {
-        viewProxy.showEmptyView()
-
-        verify(emptyView).isVisible = true
-    }
-
-    @Test
-    fun `hideEmptyView should hide emptyView`() {
-        viewProxy.hideEmptyView()
-
-        verify(emptyView).isVisible = false
     }
 
     @Test


### PR DESCRIPTION
## Summary
- don't use emptyView in DetailRepo (just hide recyclerView)
- Change getRepos to suspend function like as DetailProfilePresenter